### PR TITLE
Update jet model to assosiate reservations when delete

### DIFF
--- a/app/models/jet.rb
+++ b/app/models/jet.rb
@@ -1,5 +1,5 @@
 class Jet < ApplicationRecord
-  has_many :reservations
+  has_many :reservations, dependent: :delete_all
   has_many :users, through: :reservations
 
   validates :name, :description, :size, :category, :image, presence: true


### PR DESCRIPTION
# In this new Pull Request I'm adding the following feature:
- Update the Jet model association with reservations, so the reservations are dependent on the jet when the jet is deleted.